### PR TITLE
Stories 41-48: BPMS-initiated starts, signals, workflow end, aggregateChanged, process versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,30 @@ public void rideBooked(RideRequest request) {
 
 If the process starts with a message start event instead of a plain start event, use `startWorkflowByMessage(aggregate, messageName)` instead.
 
+#### Workflows the BPMS starts
+
+Some processes start without anybody asking: a timer start event fires, a signal start event receives a broadcast, or a conditional start event's condition becomes true. Nobody hands VanillaBP an aggregate then, so VanillaBP builds one: it instantiates the aggregate class (which needs a constructor without arguments), assigns an ID and copies the process variables the model set into attributes of the same name.
+
+Annotate a method of your workflow service if you want a say - to build the aggregate yourself:
+
+```java
+@WorkflowStartedByBpms
+public Settlement buildAggregate(BpmsStartTrigger trigger) {
+     return new Settlement(trigger.time());
+}
+```
+
+or to enrich the one VanillaBP built:
+
+```java
+@WorkflowStartedByBpms(id = "DailySettlementTimer")
+public void enrich(Settlement settlement, @TaskParam("region") String region) {
+     settlement.setRegion(region);
+}
+```
+
+The method may take the workflow aggregate, a `BpmsStartTrigger` (which kind of start event fired, when, the signal's name, the start event's id) and process variables via `@TaskParam`. Whether your BPMS can serve such a start at all is documented in the [adapter platform's wiki](https://github.com/vanillabp/adapter-platform-integration/wiki/Starting-workflows).
+
 ### Wire up a process
 
 Starting a workflow or correlating a message (explained in the [Advanced topics](#correlate-an-incoming-message) section) are actions originated in our custom business code typically triggered by some kind of business event (e.g. user hits a button). Wiring a process, a task or an expression is about connecting BPMN elements to our software components. In these situations the action to run our business code is initiated by the workflow system. So, we have to introduce markers to let the engine know where to find the right code to run.

--- a/README.md
+++ b/README.md
@@ -432,32 +432,41 @@ Two properties worth knowing. The notification is **at-least-once**, so write th
 
 ### Versioning of BPMN business-processes
 
-In case of doing breaking changes in BPMN over the time you can specify for which versions of BPMN this component is developed for:
+Once a BPMN model changes in a way older workflows cannot follow, you can tell VanillaBP which versions of the
+process a method serves:
 
 ```java
-@Component
-@WorkflowService(
-        workflowAggregateClass = Ride.class,
-        version = "<10"
-    )
-public class TaxiRide {
-  ...
-}
+@WorkflowTask(taskDefinition = "chargeCreditCard", version = "<10")
+public void chargeCreditCardUpToTen(
+        final Ride ride) { ... }
+
+@WorkflowTask(taskDefinition = "chargeCreditCard", version = ">=10")
+public void chargeCreditCard(
+        final Ride ride) { ... }
 ```
 
-Valid formats:
-* missing attribute: all versions
-* '*': all versions
-* '1': only version "1"
-* '1-3': only versions "1", "2" and "3"
-* '<3': only versions "1" and "2"
-* '<=3': only versions "1", "2" and "3"
-* '>3': only versions higher than "3"
-* '>=3': only versions higher than or equal to "3"
+The version meant is the version of the deployed process **definition** as the BPMS counts it (Camunda 7 and
+Camunda 8 count integers upwards per BPMN process id), not a version your application invents. Instead of that
+number a boundary may name a **version tag** given in the model (`camunda:versionTag` in Camunda 7,
+`zeebe:versionTag` in Camunda 8), which is what teams usually put their release name into.
 
-*Heads up:* VanillaBP 2 evaluates these ranges when it picks the method for a task, but no BPMS adapter reports the
-version of the running process yet — so today a task is matched by the methods whose range covers *all* versions
-(no attribute or `'*'`). Annotate properly to benefit from it as soon as an adapter supplies the version.
+Valid formats:
+* missing attribute or `'*'`: every version
+* `'3'`: only version "3"
+* `'release-2024'`: every version tagged that way
+* `'1-3'` or `'v1.0..v2.0'`: a range, both boundaries included
+* `'<3'` / `'<=3'`, `'>3'` / `'>=3'`: open ended, the boundary excluded respectively included
+
+Ranges accept `..` as well as `-` as their separator; use `..` whenever a boundary is a version tag containing a `-`.
+"Greater" and "less" mean the deployment order, which for a BPMS counting versions upwards is the numeric order.
+
+The same attribute exists on `@WorkflowStartedByBpms` and `@WorkflowEnded` and means the same there.
+
+Two things are worth knowing. Several methods may serve one BPMN element as long as their versions do not overlap;
+overlapping specifications are a mistake VanillaBP reports when the application starts, naming both methods. And a
+BPMS which does not report the version of a process serves every method regardless of this attribute. See the
+[adapter platform's wiki](https://github.com/vanillabp/adapter-platform-integration/wiki/Workflow-tasks#versions-of-a-process)
+for what each BPMS can tell.
 
 ### Call-activities
 

--- a/README.md
+++ b/README.md
@@ -390,6 +390,29 @@ The broadcast is scoped to the **workflow module** of the service you called: ac
 
 Within the module the signal reaches every BPMS it is deployed to, which keeps a broadcast complete while workflows are being migrated from one BPMS to another. Call it within a transaction: an embedded BPMS broadcasts inside it, and for a remote BPMS the outbox entry carrying the broadcast rides it - so a rollback takes the broadcast with it either way. There is nothing to deduplicate a signal by, so a redelivered entry may broadcast twice; do not build exactly-once expectations on it.
 
+### Tell the BPMS that the aggregate changed
+
+VanillaBP hands the aggregate's shared state to the BPMS at the moments it talks to it anyway: starting a workflow, finishing a `@WorkflowTask` method, completing or canceling a task, correlating a message. Sometimes a change has to arrive between those moments - a conditional event waits for it, or a gateway is evaluated before your next task runs:
+
+```java
+ride.setDriverArrived(true);
+rideService.aggregateChanged(ride);
+```
+
+WHAT is pushed is not decided here: it stays the part of the aggregate shared with the BPMS (`@SyncWithBPMS`). The call says "look again", nothing more - and the aggregate remains the single source of truth.
+
+The second overload picks the scope:
+
+```java
+rideService.aggregateChanged(ride, taskId);
+```
+
+With a task id the values land in the scope of THAT task instance, which is what multi-instance activities need: every instance has a scope of its own, and a workflow-wide write would be a lost update between siblings. It does **not** additionally write the workflow's global scope - so a gateway after the multi-instance evaluates the older state unless you also push globally. Pass the task id your `@TaskId` parameter was given.
+
+Call it within a transaction, like every operation reaching a BPMS. A workflow which already ended makes the push a warned no-op, a workflow no BPMS knows raises a `WorkflowNotFoundException` - and the aggregate is saved in both cases. Repeating a push is harmless: the values are read when it happens, not when it was scheduled.
+
+What a BPMS does with the new values is its own business - Camunda 7 re-evaluates the conditions of waiting conditional events, others simply hold them until something reads them.
+
 ### Learn that a workflow ended
 
 Annotate a method to be told when a workflow finished, instead of modelling a service task in front of every end event:

--- a/README.md
+++ b/README.md
@@ -376,6 +376,18 @@ In this situation the aggregate must not be persisted before.
 
 Additionally, if there are several receive tasks "waiting" for the same message then you need to define a correlation-id as a third parameter of `correlateMessage`.
 
+### Broadcast a signal
+
+A BPMN signal is a broadcast: every element waiting for it reacts, and processes having a signal start event are started by it. That is why `sendSignal` takes no workflow aggregate - unlike a message, a signal is not addressed to one workflow:
+
+```java
+rideService.sendSignal("DriversStrikeStarted");
+```
+
+Pass the signal name as modelled; VanillaBP applies the name scoping of the workflow module. No payload travels with the signal, for the same reason a message carries none: the workflow aggregate is the single source of truth.
+
+The signal reaches every BPMS the workflow module is deployed to, which keeps a broadcast complete while workflows are being migrated from one BPMS to another. Call it within a transaction: an embedded BPMS broadcasts inside it, and for a remote BPMS the outbox entry carrying the broadcast rides it - so a rollback takes the broadcast with it either way. There is nothing to deduplicate a signal by, so a redelivered entry may broadcast twice; do not build exactly-once expectations on it.
+
 ### Versioning of BPMN business-processes
 
 In case of doing breaking changes in BPMN over the time you can specify for which versions of BPMN this component is developed for:

--- a/README.md
+++ b/README.md
@@ -386,7 +386,9 @@ rideService.sendSignal("DriversStrikeStarted");
 
 Pass the signal name as modelled; VanillaBP applies the name scoping of the workflow module. No payload travels with the signal, for the same reason a message carries none: the workflow aggregate is the single source of truth.
 
-The signal reaches every BPMS the workflow module is deployed to, which keeps a broadcast complete while workflows are being migrated from one BPMS to another. Call it within a transaction: an embedded BPMS broadcasts inside it, and for a remote BPMS the outbox entry carrying the broadcast rides it - so a rollback takes the broadcast with it either way. There is nothing to deduplicate a signal by, so a redelivered entry may broadcast twice; do not build exactly-once expectations on it.
+The broadcast is scoped to the **workflow module** of the service you called: across the processes of that module, not across modules, and addressed with the tenant and client of each adapter it is deployed to. Where the module prefixes its identifiers, the signal name is prefixed too. A signal meant for several workflow modules is sent through the `ProcessService` of each of them - which modules are meant is a business decision.
+
+Within the module the signal reaches every BPMS it is deployed to, which keeps a broadcast complete while workflows are being migrated from one BPMS to another. Call it within a transaction: an embedded BPMS broadcasts inside it, and for a remote BPMS the outbox entry carrying the broadcast rides it - so a rollback takes the broadcast with it either way. There is nothing to deduplicate a signal by, so a redelivered entry may broadcast twice; do not build exactly-once expectations on it.
 
 ### Versioning of BPMN business-processes
 

--- a/README.md
+++ b/README.md
@@ -407,7 +407,9 @@ The second overload picks the scope:
 rideService.aggregateChanged(ride, taskId);
 ```
 
-With a task id the values land in the scope of THAT task instance, which is what multi-instance activities need: every instance has a scope of its own, and a workflow-wide write would be a lost update between siblings. It does **not** additionally write the workflow's global scope - so a gateway after the multi-instance evaluates the older state unless you also push globally. Pass the task id your `@TaskId` parameter was given.
+With a task id the values land in the scope that task RUNS in: the process, an embedded subprocess, or the one iteration of a multi-instance embedded subprocess. That is what multi-instance work needs, where every iteration has a scope of its own and a workflow-wide write would be a lost update between them, and it is the scope an event subprocess with a conditional start event listens on. The task's own context is deliberately skipped - values there would serve a boundary event of that task and disappear with it.
+
+It does **not** additionally write the workflow's global scope, so a gateway after the multi-instance evaluates the older state unless you also push globally. Pass the task id your `@TaskId` parameter was given.
 
 Call it within a transaction, like every operation reaching a BPMS. A workflow which already ended makes the push a warned no-op, a workflow no BPMS knows raises a `WorkflowNotFoundException` - and the aggregate is saved in both cases. Repeating a push is harmless: the values are read when it happens, not when it was scheduled.
 

--- a/README.md
+++ b/README.md
@@ -390,6 +390,21 @@ The broadcast is scoped to the **workflow module** of the service you called: ac
 
 Within the module the signal reaches every BPMS it is deployed to, which keeps a broadcast complete while workflows are being migrated from one BPMS to another. Call it within a transaction: an embedded BPMS broadcasts inside it, and for a remote BPMS the outbox entry carrying the broadcast rides it - so a rollback takes the broadcast with it either way. There is nothing to deduplicate a signal by, so a redelivered entry may broadcast twice; do not build exactly-once expectations on it.
 
+### Learn that a workflow ended
+
+Annotate a method to be told when a workflow finished, instead of modelling a service task in front of every end event:
+
+```java
+@WorkflowEnded
+public void rideFinished(Ride ride, WorkflowEnd end) {
+     ride.setClosedAt(end.time());
+}
+```
+
+VanillaBP loads the workflow aggregate, calls the method and saves the aggregate. The annotation is optional and a model without it pays nothing: adapters attach their listener only where a method exists.
+
+Two properties worth knowing. The notification is **at-least-once**, so write the method idempotently. And whether it runs in the transaction which ended the workflow depends on the BPMS: an embedded engine ends the workflow and calls the method in one transaction, a remote BPMS delivers the notification afterwards. What a BPMS can report about the KIND of end also differs - see the [adapter platform's wiki](https://github.com/vanillabp/adapter-platform-integration/wiki/Starting-workflows#when-a-workflow-ends).
+
 ### Versioning of BPMN business-processes
 
 In case of doing breaking changes in BPMN over the time you can specify for which versions of BPMN this component is developed for:

--- a/src/main/java/io/vanillabp/spi/process/ProcessService.java
+++ b/src/main/java/io/vanillabp/spi/process/ProcessService.java
@@ -40,6 +40,61 @@ public interface ProcessService<A> {
   }
 
   /**
+   * Tells the BPMS that the workflow-aggregate changed, so it sees the current
+   * state before the next thing it evaluates.
+   * <p>
+   * VanillaBP pushes the aggregate at the sync points it knows anyway (starting a
+   * workflow, completing a task, correlating a message). Between them the BPMS
+   * still holds the state of the last push - which matters when a conditional
+   * event waits for exactly this change, or when a gateway is evaluated before the
+   * next task of yours runs.
+   * <p>
+   * WHAT is pushed is not decided here: it is the part of the aggregate shared with
+   * the BPMS ({@link io.vanillabp.spi.service.SyncWithBPMS} /
+   * {@link io.vanillabp.spi.service.NoSyncWithBPMS}). This method names no
+   * variables - the aggregate stays the single source of truth.
+   * <p>
+   * What a BPMS DOES with the new values is its own business: Camunda 7 re-evaluates
+   * the conditions of waiting conditional events, other systems simply hold the
+   * values until something reads them.
+   *
+   * @param workflowAggregate The workflow-aggregate
+   * @return The workflow-aggregate attached to JPA
+   */
+  default A aggregateChanged(
+      A workflowAggregate) {
+    throw new UnsupportedOperationException(
+        "aggregateChanged is implemented by a VanillaBP adapter");
+  }
+
+  /**
+   * Tells the BPMS that the workflow-aggregate changed, pushing the shared values
+   * into the scope of ONE task instead of the workflow's global scope.
+   * <p>
+   * This is what multi-instance needs: every instance of a multi-instance activity
+   * has a scope of its own, and a workflow-wide write would be a lost update
+   * between siblings.
+   * <p>
+   * <b>It does not additionally write the global scope.</b> A value written in a
+   * task's scope shadows the global one there anyway, and writing both would change
+   * what the OTHER instances see - which is the one thing multi-instance code must
+   * not do by accident. The consequence is worth knowing: the workflow-global values
+   * stay as they were, so a gateway AFTER the multi-instance evaluates the older
+   * state unless you call {@link #aggregateChanged(Object)} as well.
+   *
+   * @param workflowAggregate The workflow-aggregate
+   * @param taskId The task-id reported previously
+   * @return The workflow-aggregate attached to JPA
+   * @see TaskId
+   */
+  default A aggregateChanged(
+      A workflowAggregate,
+      String taskId) {
+    throw new UnsupportedOperationException(
+        "aggregateChanged is implemented by a VanillaBP adapter");
+  }
+
+  /**
    * Broadcasts a BPMN signal.
    * <p>
    * A signal is a broadcast by definition: every element waiting for it reacts,

--- a/src/main/java/io/vanillabp/spi/process/ProcessService.java
+++ b/src/main/java/io/vanillabp/spi/process/ProcessService.java
@@ -49,12 +49,18 @@ public interface ProcessService<A> {
    * aggregate, and there is no way to limit a signal to a single workflow (the
    * BPMS which can do that is the exception, not the rule).
    * <p>
-   * The signal reaches every BPMS the workflow module is deployed to, which is
-   * what keeps a broadcast complete while workflows are being migrated from one
-   * BPMS to another.
+   * <b>The broadcast is scoped to the WORKFLOW MODULE of this service.</b> It
+   * reaches every BPMS the module is deployed to - which is what keeps a broadcast
+   * complete while workflows are being migrated from one BPMS to another - and
+   * every process of the module waiting for that signal. It does NOT reach other
+   * workflow modules: they are separate scopes, isolated by a tenant or by
+   * prefixed identifiers. An application wanting a signal in several modules sends
+   * it through the {@code ProcessService} of each of them; VanillaBP does not
+   * decide that for you, because which modules are meant is a business question.
    * <p>
    * Pass the signal name as it is modelled; VanillaBP applies whatever name
-   * scoping the workflow module uses.
+   * scoping the workflow module uses, and the BPMS is addressed with the tenant
+   * and the client configured for the adapter it belongs to.
    * <p>
    * No payload travels with the signal: like a message, a signal transports its
    * name and nothing else - the workflow aggregate is the single source of truth.

--- a/src/main/java/io/vanillabp/spi/process/ProcessService.java
+++ b/src/main/java/io/vanillabp/spi/process/ProcessService.java
@@ -40,6 +40,34 @@ public interface ProcessService<A> {
   }
 
   /**
+   * Broadcasts a BPMN signal.
+   * <p>
+   * A signal is a broadcast by definition: every element waiting for it reacts,
+   * and processes having a signal start event are started. It is therefore NOT
+   * addressed to one workflow - unlike
+   * {@link #correlateMessage(Object, String)}, this method takes no workflow
+   * aggregate, and there is no way to limit a signal to a single workflow (the
+   * BPMS which can do that is the exception, not the rule).
+   * <p>
+   * The signal reaches every BPMS the workflow module is deployed to, which is
+   * what keeps a broadcast complete while workflows are being migrated from one
+   * BPMS to another.
+   * <p>
+   * Pass the signal name as it is modelled; VanillaBP applies whatever name
+   * scoping the workflow module uses.
+   * <p>
+   * No payload travels with the signal: like a message, a signal transports its
+   * name and nothing else - the workflow aggregate is the single source of truth.
+   *
+   * @param signalName The BPMN signal name
+   */
+  default void sendSignal(
+      String signalName) {
+    throw new UnsupportedOperationException(
+        "sendSignal is implemented by a VanillaBP adapter");
+  }
+
+  /**
    * Correlate a message for the workflow-aggregate's workflow or its sub-workflows
    * (call-activities).
    * <p>

--- a/src/main/java/io/vanillabp/spi/process/ProcessService.java
+++ b/src/main/java/io/vanillabp/spi/process/ProcessService.java
@@ -69,15 +69,21 @@ public interface ProcessService<A> {
 
   /**
    * Tells the BPMS that the workflow-aggregate changed, pushing the shared values
-   * into the scope of ONE task instead of the workflow's global scope.
+   * into the scope the given task RUNS IN instead of the workflow's global scope.
    * <p>
-   * This is what multi-instance needs: every instance of a multi-instance activity
-   * has a scope of its own, and a workflow-wide write would be a lost update
-   * between siblings.
+   * That scope is the process, an embedded subprocess, or the one iteration of a
+   * multi-instance embedded subprocess the task belongs to - what the rest of that
+   * scope evaluates, and what an event subprocess with a conditional start event
+   * listens on. Deliberately NOT the task's own context: values written there would
+   * serve a boundary event of that task and nothing else, and they disappear with the
+   * task.
    * <p>
-   * <b>It does not additionally write the global scope.</b> A value written in a
-   * task's scope shadows the global one there anyway, and writing both would change
-   * what the OTHER instances see - which is the one thing multi-instance code must
+   * This is what multi-instance work needs: every iteration has a scope of its own,
+   * and a workflow-wide write would be a lost update between the iterations.
+   * <p>
+   * <b>It does not additionally write the global scope.</b> A value written in an
+   * inner scope shadows the global one there anyway, and writing both would change
+   * what the OTHER iterations see - which is the one thing multi-instance code must
    * not do by accident. The consequence is worth knowing: the workflow-global values
    * stay as they were, so a gateway AFTER the multi-instance evaluates the older
    * state unless you call {@link #aggregateChanged(Object)} as well.

--- a/src/main/java/io/vanillabp/spi/process/ProcessService.java
+++ b/src/main/java/io/vanillabp/spi/process/ProcessService.java
@@ -64,6 +64,11 @@ public interface ProcessService<A> {
    * <p>
    * No payload travels with the signal: like a message, a signal transports its
    * name and nothing else - the workflow aggregate is the single source of truth.
+   * <p>
+   * <b>A signal is not buffered.</b> It reaches whoever waits for it at that very
+   * moment; a workflow arriving at its catch event a moment later gets nothing.
+   * Where a delivery has to wait for its recipient, correlate a message to that
+   * workflow instead.
    *
    * @param signalName The BPMN signal name
    */

--- a/src/main/java/io/vanillabp/spi/service/BpmsStartTrigger.java
+++ b/src/main/java/io/vanillabp/spi/service/BpmsStartTrigger.java
@@ -1,0 +1,42 @@
+package io.vanillabp.spi.service;
+
+import java.time.Instant;
+
+/**
+ * What made the BPMS start a workflow on its own - handed to a
+ * {@link WorkflowStartedByBpms} method which declares a parameter of this type.
+ *
+ * @param kind Which kind of start event fired
+ * @param time When it fired: a timer's scheduled time as the engine reports it,
+ *          otherwise the moment VanillaBP was notified
+ * @param signalName The name of the signal for {@link Kind#SIGNAL},
+ *          <code>null</code> otherwise
+ * @param startEventId The BPMN id of the start event which fired
+ */
+public record BpmsStartTrigger(
+                               Kind kind,
+                               Instant time,
+                               String signalName,
+                               String startEventId) {
+
+  /**
+   * The kinds of start event a BPMS fires without the application asking for it.
+   * Message start events are NOT among them: those are triggered by the
+   * application through
+   * {@link io.vanillabp.spi.process.ProcessService#startWorkflowByMessage(Object, String)},
+   * which carries the aggregate.
+   */
+  public enum Kind {
+
+    /** A timer start event, including cyclic ones. */
+    TIMER,
+
+    /** A signal start event, fired by a broadcast signal. */
+    SIGNAL,
+
+    /** A conditional start event whose condition became true. */
+    CONDITIONAL
+
+  }
+
+}

--- a/src/main/java/io/vanillabp/spi/service/WorkflowEnd.java
+++ b/src/main/java/io/vanillabp/spi/service/WorkflowEnd.java
@@ -1,0 +1,39 @@
+package io.vanillabp.spi.service;
+
+import java.time.Instant;
+
+/**
+ * How a workflow ended - handed to a {@link WorkflowEnded} method which declares a
+ * parameter of this type.
+ *
+ * @param kind How it ended, as far as the BPMS reports it
+ * @param time When it ended, as the BPMS reports it or - where it does not - the
+ *          moment VanillaBP was notified
+ * @param endEventId The BPMN id of the end event reached, or <code>null</code>
+ *          where the BPMS does not report which one it was
+ */
+public record WorkflowEnd(
+                          Kind kind,
+                          Instant time,
+                          String endEventId) {
+
+  /**
+   * How a workflow ended. Which of these a BPMS can tell apart differs; an adapter
+   * whose BPMS cannot distinguish them reports {@link #COMPLETED} and its
+   * documentation says so - a faked distinction would be worse than none.
+   */
+  public enum Kind {
+
+    /** The workflow reached an end event. */
+    COMPLETED,
+
+    /**
+     * The workflow was ended without reaching an end event: cancelled or deleted
+     * by an operator, terminated by a terminate end event, or interrupted by an
+     * event of an enclosing scope.
+     */
+    TERMINATED
+
+  }
+
+}

--- a/src/main/java/io/vanillabp/spi/service/WorkflowEnded.java
+++ b/src/main/java/io/vanillabp/spi/service/WorkflowEnded.java
@@ -49,19 +49,33 @@ public @interface WorkflowEnded {
   String id() default ANY_END_EVENT;
 
   /**
-   * Can be used to define certain versions or ranges of versions of a process for
-   * which the annotated method should be used for.
+   * Which versions of the deployed BPMN process this method serves. The version is
+   * the version of the process DEFINITION as the BPMS counts it (Camunda 7 and
+   * Camunda 8 count integers upwards per BPMN process id), not a version the
+   * application invents.
    * <p>
-   * Format:
+   * A boundary is either such a version or a version TAG given in the model
+   * (<code>camunda:versionTag</code> in Camunda 7, <code>zeebe:versionTag</code> in
+   * Camunda 8):
    * <ul>
-   * <li><i>*</i>: all versions
-   * <li><i>1</i>: only version &quot;1&quot;
-   * <li><i>1-3</i>: only versions &quot;1&quot;, &quot;2&quot; and &quot;3&quot;
-   * <li><i>&gt;3</i>: only versions higher than &quot;3&quot;
-   * <li><i>&lt;3</i>: only versions less than &quot;3&quot;</li>
+   * <li><i>*</i>: every version (the default)
+   * <li><i>3</i> or <i>release-2024</i>: exactly that version, respectively every
+   * version carrying that tag
+   * <li><i>1-3</i> or <i>v1.0..v2.0</i>: a range, both boundaries included
+   * <li><i>&gt;3</i>, <i>&lt;v2.0</i>: open ended</li>
    * </ul>
+   * Ranges accept <code>..</code> as well as <code>-</code> as their separator; a
+   * boundary naming a tag which contains a <code>-</code> has to use <code>..</code>.
+   * &quot;Greater&quot; and &quot;less&quot; mean the deployment order, which for a
+   * BPMS counting versions upwards is the numeric order.
+   * <p>
+   * Several methods may serve one BPMN element as long as their versions do not
+   * overlap - overlapping specifications are reported when the application starts.
+   * A BPMS which does not report the version of a process serves every method
+   * regardless of this attribute, and specifications naming a version tag need a
+   * BPMS which can be asked about its tags (Camunda 8 needs its query API for that).
    *
-   * @return The version of the process this method belongs to.
+   * @return The versions of the deployed BPMN process this method serves.
    */
   String[] version() default "*";
 

--- a/src/main/java/io/vanillabp/spi/service/WorkflowEnded.java
+++ b/src/main/java/io/vanillabp/spi/service/WorkflowEnded.java
@@ -1,0 +1,68 @@
+package io.vanillabp.spi.service;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Marks the method to be called once a workflow ended. Without it an application
+ * learns of the end only by modelling a service task in front of every end event -
+ * BPMN noise for a fact the engine knows anyway.
+ *
+ * <pre>
+ * &#64;WorkflowEnded
+ * public void rideFinished(final Ride ride, final {@link WorkflowEnd} end) {
+ *   ride.setClosedAt(end.time());
+ * }
+ * </pre>
+ *
+ * The method may take the workflow aggregate and a {@link WorkflowEnd} in any
+ * order. VanillaBP loads the aggregate, calls the method and saves the aggregate,
+ * so recording the outcome is all the method has to do.
+ * <p>
+ * The annotation is OPTIONAL, and a model without it pays nothing: adapters attach
+ * their listener only where a method exists.
+ * <p>
+ * <b>The notification is at-least-once</b> - after a crash or a retried delivery it
+ * may arrive twice, so write it idempotently (which recording a status is). Whether
+ * it runs in the transaction ending the workflow depends on the BPMS: an embedded
+ * engine ends the workflow and calls the method in ONE transaction, a remote BPMS
+ * delivers the notification afterwards.
+ */
+@Retention(RUNTIME)
+@Target(METHOD)
+@Inherited
+@Documented
+public @interface WorkflowEnded {
+
+  static String ANY_END_EVENT = "";
+
+  /**
+   * @return The BPMN id of the end event this method serves. Defaults to every end
+   *         of the workflow, which is what a process ending in one place needs -
+   *         and the only thing a BPMS reporting no element id can serve.
+   */
+  String id() default ANY_END_EVENT;
+
+  /**
+   * Can be used to define certain versions or ranges of versions of a process for
+   * which the annotated method should be used for.
+   * <p>
+   * Format:
+   * <ul>
+   * <li><i>*</i>: all versions
+   * <li><i>1</i>: only version &quot;1&quot;
+   * <li><i>1-3</i>: only versions &quot;1&quot;, &quot;2&quot; and &quot;3&quot;
+   * <li><i>&gt;3</i>: only versions higher than &quot;3&quot;
+   * <li><i>&lt;3</i>: only versions less than &quot;3&quot;</li>
+   * </ul>
+   *
+   * @return The version of the process this method belongs to.
+   */
+  String[] version() default "*";
+
+}

--- a/src/main/java/io/vanillabp/spi/service/WorkflowStartedByBpms.java
+++ b/src/main/java/io/vanillabp/spi/service/WorkflowStartedByBpms.java
@@ -1,0 +1,78 @@
+package io.vanillabp.spi.service;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Marks the method building the workflow-aggregate of a workflow the BPMS started
+ * on its own: by a timer, a signal or a conditional start event. Unlike every other
+ * workflow, nobody called
+ * {@link io.vanillabp.spi.process.ProcessService#startWorkflow(Object)} - the engine
+ * decided, and the aggregate has to come into existence for the workflow to have
+ * any data at all.
+ * <p>
+ * The annotation is OPTIONAL. Without it VanillaBP builds the aggregate itself: it
+ * instantiates the class, assigns an ID (a timer's trigger time, otherwise a
+ * generated ID) and copies the process variables the BPMN model set into
+ * equally-named attributes. Annotate a method to take that over:
+ *
+ * <pre>
+ * &#64;WorkflowStartedByBpms
+ * public Ride buildAggregate(final {@link BpmsStartTrigger} trigger) {
+ *   return new Ride(trigger.time());
+ * }
+ * </pre>
+ *
+ * or to enrich the aggregate VanillaBP built:
+ *
+ * <pre>
+ * &#64;WorkflowStartedByBpms(id = "DailySettlementTimer")
+ * public void enrich(final Settlement settlement, &#64;{@link TaskParam}("region") final String region) {
+ *   settlement.setRegion(region);
+ * }
+ * </pre>
+ *
+ * The method may take the workflow aggregate, a {@link BpmsStartTrigger} and
+ * {@link TaskParam} annotated process variables in any order. It runs in the
+ * transaction VanillaBP opened for the start; the aggregate is saved afterwards.
+ * Throwing means the workflow does not start: the aggregate is rolled back and the
+ * BPMS applies its retry semantics.
+ */
+@Retention(RUNTIME)
+@Target(METHOD)
+@Inherited
+@Documented
+public @interface WorkflowStartedByBpms {
+
+  static String ANY_START_EVENT = "";
+
+  /**
+   * @return The BPMN id of the start event this method serves. Defaults to every
+   *         BPMS-initiated start event of the process - which is what a process
+   *         with exactly one such start event needs.
+   */
+  String id() default ANY_START_EVENT;
+
+  /**
+   * Can be used to define certain versions or ranges of versions of a process for
+   * which the annotated method should be used for.
+   * <p>
+   * Format:
+   * <ul>
+   * <li><i>*</i>: all versions
+   * <li><i>1</i>: only version &quot;1&quot;
+   * <li><i>1-3</i>: only versions &quot;1&quot;, &quot;2&quot; and &quot;3&quot;
+   * <li><i>&gt;3</i>: only versions higher than &quot;3&quot;
+   * <li><i>&lt;3</i>: only versions less than &quot;3&quot;</li>
+   * </ul>
+   *
+   * @return The version of the process this method belongs to.
+   */
+  String[] version() default "*";
+
+}

--- a/src/main/java/io/vanillabp/spi/service/WorkflowStartedByBpms.java
+++ b/src/main/java/io/vanillabp/spi/service/WorkflowStartedByBpms.java
@@ -59,19 +59,33 @@ public @interface WorkflowStartedByBpms {
   String id() default ANY_START_EVENT;
 
   /**
-   * Can be used to define certain versions or ranges of versions of a process for
-   * which the annotated method should be used for.
+   * Which versions of the deployed BPMN process this method serves. The version is
+   * the version of the process DEFINITION as the BPMS counts it (Camunda 7 and
+   * Camunda 8 count integers upwards per BPMN process id), not a version the
+   * application invents.
    * <p>
-   * Format:
+   * A boundary is either such a version or a version TAG given in the model
+   * (<code>camunda:versionTag</code> in Camunda 7, <code>zeebe:versionTag</code> in
+   * Camunda 8):
    * <ul>
-   * <li><i>*</i>: all versions
-   * <li><i>1</i>: only version &quot;1&quot;
-   * <li><i>1-3</i>: only versions &quot;1&quot;, &quot;2&quot; and &quot;3&quot;
-   * <li><i>&gt;3</i>: only versions higher than &quot;3&quot;
-   * <li><i>&lt;3</i>: only versions less than &quot;3&quot;</li>
+   * <li><i>*</i>: every version (the default)
+   * <li><i>3</i> or <i>release-2024</i>: exactly that version, respectively every
+   * version carrying that tag
+   * <li><i>1-3</i> or <i>v1.0..v2.0</i>: a range, both boundaries included
+   * <li><i>&gt;3</i>, <i>&lt;v2.0</i>: open ended</li>
    * </ul>
+   * Ranges accept <code>..</code> as well as <code>-</code> as their separator; a
+   * boundary naming a tag which contains a <code>-</code> has to use <code>..</code>.
+   * &quot;Greater&quot; and &quot;less&quot; mean the deployment order, which for a
+   * BPMS counting versions upwards is the numeric order.
+   * <p>
+   * Several methods may serve one BPMN element as long as their versions do not
+   * overlap - overlapping specifications are reported when the application starts.
+   * A BPMS which does not report the version of a process serves every method
+   * regardless of this attribute, and specifications naming a version tag need a
+   * BPMS which can be asked about its tags (Camunda 8 needs its query API for that).
    *
-   * @return The version of the process this method belongs to.
+   * @return The versions of the deployed BPMN process this method serves.
    */
   String[] version() default "*";
 

--- a/src/main/java/io/vanillabp/spi/service/WorkflowTask.java
+++ b/src/main/java/io/vanillabp/spi/service/WorkflowTask.java
@@ -39,19 +39,33 @@ public @interface WorkflowTask {
   String taskDefinition() default USE_METHOD_NAME;
 
   /**
-   * Can be used to define certain versions or ranges of versions of a process for
-   * which the annotated method should be used for.
+   * Which versions of the deployed BPMN process this method serves. The version is
+   * the version of the process DEFINITION as the BPMS counts it (Camunda 7 and
+   * Camunda 8 count integers upwards per BPMN process id), not a version the
+   * application invents.
    * <p>
-   * Format:
+   * A boundary is either such a version or a version TAG given in the model
+   * (<code>camunda:versionTag</code> in Camunda 7, <code>zeebe:versionTag</code> in
+   * Camunda 8):
    * <ul>
-   * <li><i>*</i>: all versions
-   * <li><i>1</i>: only version &quot;1&quot;
-   * <li><i>1-3</i>: only versions &quot;1&quot;, &quot;2&quot; and &quot;3&quot;
-   * <li><i>&gt;3</i>: only versions higher than &quot;3&quot;
-   * <li><i>&lt;3</i>: only versions less than &quot;3&quot;</li>
+   * <li><i>*</i>: every version (the default)
+   * <li><i>3</i> or <i>release-2024</i>: exactly that version, respectively every
+   * version carrying that tag
+   * <li><i>1-3</i> or <i>v1.0..v2.0</i>: a range, both boundaries included
+   * <li><i>&gt;3</i>, <i>&lt;v2.0</i>: open ended</li>
    * </ul>
-   * 
-   * @return The version of the process this method belongs to.
+   * Ranges accept <code>..</code> as well as <code>-</code> as their separator; a
+   * boundary naming a tag which contains a <code>-</code> has to use <code>..</code>.
+   * &quot;Greater&quot; and &quot;less&quot; mean the deployment order, which for a
+   * BPMS counting versions upwards is the numeric order.
+   * <p>
+   * Several methods may serve one BPMN element as long as their versions do not
+   * overlap - overlapping specifications are reported when the application starts.
+   * A BPMS which does not report the version of a process serves every method
+   * regardless of this attribute, and specifications naming a version tag need a
+   * BPMS which can be asked about its tags (Camunda 8 needs its query API for that).
+   *
+   * @return The versions of the deployed BPMN process this method serves.
    */
   String[] version() default "*";
 


### PR DESCRIPTION
The SPI half of the stories 41 to 48: annotations and value types the platform and the
adapters implement.

- `@WorkflowStartedByBpms` plus `BpmsStartTrigger`: a workflow the BPMS starts on its own
  gets its aggregate, and an application method may have a say (story 41).
- `@WorkflowEnded` plus `WorkflowEnd`: an application learns that a workflow ended instead
  of modelling a service task in front of every end event (story 43).
- `ProcessService.sendSignal` (story 42) and `ProcessService.aggregateChanged` in two
  overloads (story 44).
- `version` says what it matches against: the version of the deployed process definition
  as the BPMS counts it, or a version tag of the model (story 48).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JfGxTzh2x1suKFoJJv5aXS