### PR TITLE
CI builds with --update-snapshots

### DIFF
--- a/.github/workflows/deploy-to-github-packages.yaml
+++ b/.github/workflows/deploy-to-github-packages.yaml
@@ -23,7 +23,7 @@ jobs:
           distribution: temurin
           cache: maven
       - name: Publish package
-        run: mvn --batch-mode deploy
+        run: mvn --batch-mode --update-snapshots deploy
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CI: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Set Maven release version
         run: |
-          mvn --batch-mode versions:set -DnewVersion=${{ github.event.inputs.release_version }}
+          mvn --batch-mode --update-snapshots versions:set -DnewVersion=${{ github.event.inputs.release_version }}
           find . -name pom.xml.versionsBackup -delete
 
       - name: Check for SNAPSHOT dependencies
@@ -76,7 +76,7 @@ jobs:
 
       - name: Build & deploy to Maven Central
         run: |
-          mvn --batch-mode -DskipTests -DskipITs -Dgpg.passphrase=$GPG_PASSPHRASE \
+          mvn --batch-mode --update-snapshots -DskipTests -DskipITs -Dgpg.passphrase=$GPG_PASSPHRASE \
           clean deploy -P release,central-portal
         env:
           GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
@@ -115,9 +115,9 @@ jobs:
 
       - name: Set next snapshot version
         run: |
-          mvn --batch-mode versions:set -DnewVersion=${{ env.NEXT_SNAPSHOT }}
+          mvn --batch-mode --update-snapshots versions:set -DnewVersion=${{ env.NEXT_SNAPSHOT }}
           find . -name pom.xml.versionsBackup -delete
-          mvn --batch-mode -DskipTests -DskipITs package
+          mvn --batch-mode --update-snapshots -DskipTests -DskipITs package
 
       - name: Commit next snapshot version
         run: |  


### PR DESCRIPTION
A cached Maven repository in the GitHub action served a stale snapshot, which showed up as an `AbstractMethodError` in a blueprint instead of a build failure here. Applied to every Maven command of this repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jss55UjjvxYcLQPVFUFe25