### PR TITLE
A Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>vanillabp/renovate-config"],
+  "timezone": "Europe/Vienna",
+  "packageRules": [
+    {
+      "description": "VanillaBP artifacts follow the framework, not Renovate: their versions are bumped when a release is cut, and while they are snapshots there is nothing to look up.",
+      "matchPackageNames": ["/^io\\.vanillabp/"],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
Story 53 set up Renovate in the repositories that had none. This one only needs the base: the
organisation preset, and the VanillaBP artifacts excluded because their versions follow the
framework's release rather than a bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
